### PR TITLE
Handle non-name assignments

### DIFF
--- a/flake8_empty_init_modules.py
+++ b/flake8_empty_init_modules.py
@@ -36,7 +36,7 @@ class _EIM002Visitor(ast.NodeVisitor):
         return (
             isinstance(node, ast.Assign)
             and all(
-                target.id == '__all__'  # type: ignore[attr-defined]
+                isinstance(target, ast.Name) and target.id == '__all__'
                 for target in node.targets
             )
         )

--- a/tests/flake8_empty_init_modules_test.py
+++ b/tests/flake8_empty_init_modules_test.py
@@ -9,13 +9,15 @@ PYTHON_MODULE = '''\
 """This is the module docstring."""
 
 # convenience imports:
-import json
+import os
 from pathlib import Path
 
-__all__ = ['json', 'Path']
+__all__ = ['MY_CONSTANT']
 
 MY_CONSTANT = 5
 """This is an important constant."""
+
+os.environ['FOO'] = 1
 '''
 
 
@@ -41,6 +43,7 @@ class TestEIM001:
             (7, 0, 'EIM001 code in `__init__.py` module', EIM001),
             (9, 0, 'EIM001 code in `__init__.py` module', EIM001),
             (10, 0, 'EIM001 code in `__init__.py` module', EIM001),
+            (12, 0, 'EIM001 code in `__init__.py` module', EIM001),
         }
 
     def test_non_init_module(self):
@@ -57,6 +60,7 @@ class TestEIM002:
     def test_init_module_with_code(self):
         assert self._run('my_package/__init__.py', PYTHON_MODULE) == {
             (9, 0, 'EIM002 non-import code in `__init__.py` module', EIM002),
+            (12, 0, 'EIM002 non-import code in `__init__.py` module', EIM002),
         }
 
     def test_non_init_module(self):


### PR DESCRIPTION
Prior to this change, when looking for assignments to `__all__`, we
could not handle non-name assignments (subscripts, list expansion,
etc.).

This change allows us to handle these by correctly inferring that they
are not valid.
